### PR TITLE
FGTV schema fix + ippu_florinated_gases NameError fix + activate detailed fuel cost factors

### DIFF
--- a/costs_benefits_ssp/cb_calculate.py
+++ b/costs_benefits_ssp/cb_calculate.py
@@ -341,8 +341,34 @@ class CostBenefits:
             if v.startswith("emission_co2e_")
             and not ("_co2_" in v or "_n2o_" in v or "_ch4_" in v or "_subsector_" in v)
         ]
-        _fgtv_rx = re.compile(r"emission_co2e_.*_fgtv_fuel_.*")
+        # Match both the legacy fugitive emissions format
+        #   emission_co2e_<gas>_fgtv_fuel_<fuel>
+        # and the new stage-split format used by recent SISEPUEDE runs
+        #   emission_co2e_<gas>_fgtv_<stage>_fuel_<fuel>
+        # where <stage> ∈ {dtp, flaring, venting}. The `.*fuel_` piece is
+        # optional in practice because `.*` can match an empty string.
+        _fgtv_rx = re.compile(r"emission_co2e_.*_fgtv_.*fuel_.*")
         self._fgtv_vars = [v for v in self.ssp_list_of_vars if _fgtv_rx.match(v)]
+
+        # Derive the set of fuel keys (e.g. "fuel_coal", "fuel_natural_gas")
+        # that actually appear in the fgtv columns of this run. This is
+        # format-agnostic: for legacy columns `emission_co2e_ch4_fgtv_fuel_coal`
+        # and for new columns `emission_co2e_ch4_fgtv_flaring_fuel_coal` the
+        # extraction yields the same key `fuel_coal`.
+        self._fgtv_fuels = sorted({
+            "fuel_" + v.rsplit("fuel_", 1)[-1]
+            for v in self._fgtv_vars
+        })
+        # Only keep fuels that have a matching total energy demand column —
+        # these are the ones usable to compute fugitive intensity. In recent
+        # runs this typically includes coal, crude, natural_gas and oil; in
+        # older runs only coal, natural_gas and oil.
+        self._fgtv_energy_vars = [
+            f"energy_demand_enfu_total_{fk}"
+            for fk in self._fgtv_fuels
+            if f"energy_demand_enfu_total_{fk}" in self._ssp_col_set
+        ]
+
         self._ccs_fraction_vars = [
             v for v in self.ssp_list_of_vars
             if v.startswith("frac_ippu_production_with_co2_capture_")
@@ -1444,16 +1470,31 @@ class CostBenefits:
                 data = self.ssp_data
                     
             #(1) FUGITIVE EMISSIONS INTENSITY
-            energy_vars = ['energy_demand_enfu_total_fuel_coal', 'energy_demand_enfu_total_fuel_oil', 'energy_demand_enfu_total_fuel_natural_gas']
-            # Precomputed in cache (the previous code scanned ssp_list_of_vars on every call).
+            # Both `energy_vars` and `fgtv_vars` are precomputed in
+            # `_build_caches` and are format-agnostic: they work both for the
+            # legacy fugitive columns (emission_co2e_<gas>_fgtv_fuel_<fuel>)
+            # and for the new stage-split format
+            # (emission_co2e_<gas>_fgtv_<stage>_fuel_<fuel>). The fuel list is
+            # derived from the actual columns present in this run, so adding
+            # `crude` as a new fuel in recent SISEPUEDE versions is handled
+            # automatically.
+            energy_vars = self._fgtv_energy_vars
             fgtv_vars = self._fgtv_vars
 
+            if not fgtv_vars or not energy_vars:
+                # This run has no fugitive-emission columns at all, so there
+                # is nothing to compute. Returning an empty DataFrame (with
+                # the expected columns) lets the caller concat it cleanly.
+                return pd.DataFrame(columns=SSP_GLOBAL_COLNAMES_OF_RESULTS)
+
             #1. Get the fugitive emissions per PJ of coal and oil together in the baseline
-            # Vectorized string ops (antes usaban .apply con lambda).
+            # Vectorized string ops. The `rsplit("fuel_", n=1)` pattern extracts
+            # the fuel key regardless of whether the variable is legacy
+            # (`..._fgtv_fuel_coal`) or split (`..._fgtv_flaring_fuel_coal`).
             energy = self.cb_get_data_from_wide_to_long(data, cb_orm.strategy_code_base, energy_vars)
             energy["fuel"] = energy["variable"].str.replace("energy_demand_enfu_total_", "", regex=False)
             fgtv = self.cb_get_data_from_wide_to_long(data, cb_orm.strategy_code_base, fgtv_vars)
-            fgtv["fuel"] = fgtv["variable"].str.rsplit("_fgtv_", n=1).str[-1]
+            fgtv["fuel"] = "fuel_" + fgtv["variable"].str.rsplit("fuel_", n=1).str[-1]
 
             #1.a summarize the emissions by fuel
             vars_to_groupby = ["primary_id", "region", "time_period", "strategy_code", "fuel"]
@@ -1465,7 +1506,7 @@ class CostBenefits:
             energy_tx = self.cb_get_data_from_wide_to_long(data, cb_orm.strategy_code_tx, energy_vars)
             energy_tx["fuel"] = energy_tx["variable"].str.replace("energy_demand_enfu_total_", "", regex=False)
             fgtv_tx = self.cb_get_data_from_wide_to_long(data, cb_orm.strategy_code_tx, fgtv_vars)
-            fgtv_tx["fuel"] = fgtv_tx["variable"].str.rsplit("_fgtv_", n=1).str[-1]
+            fgtv_tx["fuel"] = "fuel_" + fgtv_tx["variable"].str.rsplit("fuel_", n=1).str[-1]
 
             #2.b summarize the emissions by fuel
             fgtv_tx = fgtv_tx.groupby(vars_to_groupby).agg({"value" : "sum"}).reset_index()
@@ -1498,10 +1539,13 @@ class CostBenefits:
 
             data_merged = data_merged[SSP_GLOBAL_COLNAMES_OF_RESULTS]
 
-            #8. If tehre are NANs or NAs in the value, replace them with 0.
-            data_merged.replace(np.nan, 0.0)
-
-
+            #8. If there are NaNs/NAs in the value, replace them with 0.
+            # Fix: the previous code called `.replace(np.nan, 0.0)` without
+            # assigning the result, so the replacement was silently dropped.
+            # This is especially important for fuels like `crude` whose
+            # baseline demand may be zero, producing 0/0 = NaN in the
+            # intensity calculation.
+            data_merged = data_merged.fillna(0.0)
 
             return data_merged
         else:

--- a/costs_benefits_ssp/cb_calculate.py
+++ b/costs_benefits_ssp/cb_calculate.py
@@ -1416,7 +1416,10 @@ class CostBenefits:
         
             data_strategy_summarized = data_strategy.groupby(["region", "time_period", "strategy_code"]).agg({"value" : "sum"}).rename(columns = {"value" : "difference_value"}).reset_index()
             data_strategy_summarized["difference_variable"] = 'emission_co2e_all_fgases_ippu'
-            data_strategy_summarized["variable"] = output_vars
+            # Fix: the old code referenced an undefined name `output_vars`.
+            # The intended value is the configured output variable name,
+            # matching what the baseline branch assigns a few lines below.
+            data_strategy_summarized["variable"] = cb_orm.output_variable_name
 
 
             data_strategy_base = self.cb_get_data_from_wide_to_long(data, cb_orm.strategy_code_base, fgases)

--- a/costs_benefits_ssp/cb_calculate.py
+++ b/costs_benefits_ssp/cb_calculate.py
@@ -624,7 +624,20 @@ class CostBenefits:
             
             if cb_orm.cb_var_group == 'wali_sanitation_cost_factors' or cb_orm.cb_var_group == 'wali_benefit_of_sanitation_cost_factors':
                 cb_orm.cb_function = 'cb_difference_between_two_strategies'
-            
+
+            # Activate the detailed per-sector × per-fuel fuel cost factors
+            # (cb:enfu:fuel_cost:<sector>:<fuel>). These rows live in
+            # `cost_factors` with `cb_function='cb_strategy_specific_function'`
+            # which is not implemented, so historically they were dead code.
+            # Their `difference_variable` values are real SSP output columns
+            # (`totalvalue_enfu_fuel_consumed_<sector>_fuel_<fuel>`), so we
+            # rescue them to `cb_difference_between_two_strategies`. The
+            # aggregate `cb:enfu:fuel_cost:X:X` (cb_var_group='enfu_fuel_cost_factors',
+            # note: no `_detail` suffix) is intentionally NOT rescued here to
+            # avoid double counting with the detail.
+            if cb_orm.cb_var_group == 'enfu_fuel_cost_factors_detail':
+                cb_orm.cb_function = 'cb_difference_between_two_strategies'
+
             if cb_orm.cb_function=="cb:enfu:fuel_cost:X:X":
                 cb_orm.cb_function = 'cb_difference_between_two_strategies'
 

--- a/costs_benefits_ssp/decorators/cb_wrappers.py
+++ b/costs_benefits_ssp/decorators/cb_wrappers.py
@@ -40,6 +40,16 @@ def cb_wrapper(func):
                 if cb_orm.cb_var_group == 'wali_sanitation_cost_factors' or cb_orm.cb_var_group == 'wali_benefit_of_sanitation_cost_factors':
                     cb_orm.cb_function = 'cb_difference_between_two_strategies'
 
+                # Activate the detailed per-sector × per-fuel fuel cost
+                # factors. See the equivalent block in
+                # `CostBenefits.compute_cost_benefit_from_variable` for the
+                # full rationale. The aggregate `cb:enfu:fuel_cost:X:X`
+                # (`cb_var_group='enfu_fuel_cost_factors'`, without the
+                # `_detail` suffix) is NOT rescued here to avoid double
+                # counting with the detail.
+                if cb_orm.cb_var_group == 'enfu_fuel_cost_factors_detail':
+                    cb_orm.cb_function = 'cb_difference_between_two_strategies'
+
                 if cb_orm.cb_function == "cb:enfu:fuel_cost:X:X":
                     cb_orm.cb_function = 'cb_difference_between_two_strategies'
 


### PR DESCRIPTION
## Summary

Three follow-up changes after the initial optimization PR (#3) was merged. All three are needed for the package to work correctly against recent SISEPUEDE outputs (e.g. the Libya runs).

## Changes

### 1. FGTV stage-split compatibility (`6fc989f`)

Recent SISEPUEDE runs split the fugitive-emission outputs from the legacy

```
emission_co2e_<gas>_fgtv_fuel_<fuel>              (9 columns: 3×3)
```

into the new stage-split layout

```
emission_co2e_<gas>_fgtv_<stage>_fuel_<fuel>      (36 columns: 3×3×4)
```

with `<stage>` ∈ `{dtp, flaring, venting}` and `<fuel>` ∈ `{coal, crude, natural_gas, oil}`.

The old `cb_fgtv_abatement_costs` pipeline broke in three places:
- `_fgtv_vars` regex required the literal `_fgtv_fuel_` substring → 0 matches → 0 rows generated for `TX:FGTV:INC_FLARE` and `TX:FGTV:DEC_LEAKS`.
- Fuel-key extraction `rsplit("_fgtv_", n=1)` returned `flaring_fuel_coal` instead of `fuel_coal`, breaking the merge with the `energy_demand_enfu_total_fuel_*` side.
- `energy_vars` was hardcoded to `coal/oil/natural_gas` and didn't include the new `crude` fuel.

The fix:
- Widens the `_fgtv_vars` regex to `emission_co2e_.*_fgtv_.*fuel_.*` so it matches both formats.
- Precomputes `_fgtv_fuels` and `_fgtv_energy_vars` dynamically from the actual columns present in the run, so adding new fuels in future SISEPUEDE versions requires no code changes.
- Replaces the fuel extraction with `"fuel_" + variable.str.rsplit("fuel_", n=1).str[-1]`, format-agnostic.
- Bonus: fixes a pre-existing NaN leak (`data_merged.replace(np.nan, 0.0)` was called without assignment).

### 2. NameError fix in `cb_ippu_florinated_gases` (`cc446b9`)

`cb_ippu_florinated_gases` referenced an undefined `output_vars` symbol. Any strategy containing `TX:IPPU:BUNDLE_DEC_FGAS` would crash with `NameError`. Replaced with `cb_orm.output_variable_name`, matching what the baseline branch of the same function does six lines below.

### 3. Activate detailed per-sector × per-fuel fuel cost factors (`fc9c873`)

47 cost_factors with `cb_var_group='enfu_fuel_cost_factors_detail'` were dead code in the backup db: their `cb_function='cb_strategy_specific_function'` is not wired up in `mapping_strategy_specific_functions`, so they silently returned `None` and never contributed to the output.

These rows are of the form

```
cb:enfu:fuel_cost:<sector>:<fuel>
  difference_variable = totalvalue_enfu_fuel_consumed_<sector>_fuel_<fuel>
  multiplier          = -500000.0   (benefit from reduced fuel consumption)
  cb_var_group        = enfu_fuel_cost_factors_detail
```

with `<sector>` ∈ `{ccsq, entc, inen, scoe, trns}`. The `difference_variable` columns are real SSP outputs and exist in both the legacy and the modern output schemas, so this was a missing dispatch — not a schema-change problem.

The fix adds a rescue branch in two places (`compute_cost_benefit_from_variable` and `cb_wrapper`) that rewrites `cb_function` → `cb_difference_between_two_strategies` whenever `cb_var_group == 'enfu_fuel_cost_factors_detail'`. The existing `wali_sanitation*` rescue follows the exact same pattern.

**Double counting is avoided**: the aggregate `cb:enfu:fuel_cost:X:X` row (`cb_var_group='enfu_fuel_cost_factors'`, no `_detail` suffix) is intentionally NOT rescued. There is a pre-existing buggy branch in `cb_wrapper` that compares `cb_function` against the literal `"cb:enfu:fuel_cost:X:X"` (which is an `output_variable_name`, not a function name), so the aggregate stays dead. We did NOT touch that legacy branch on purpose.

## Behavioral impact

This PR is **not** semantics-preserving overall:

| Stage | Hash before | Hash after | Reason |
|---|---|---|---|
| `system` | `6452611b09bbeb4e` | `b34a79fd907085dc` | 47 new variables activated |
| `technical` | `029bce4c65e45da9` | `029bce4c65e45da9` | Unchanged: transformation_costs untouched |
| `interactions` | `832f7a75e4b10994` | `074d01767f518fe9` | Consumes `concat(system+technical)`, larger input |

- **system cost**: +13 536 rows per run on `test_data/` (47 variables × 8 strategies × 36 time periods).
- Variable values are in the expected $10⁸–10⁹ range for sectors with material fuel demand changes.
- FGTV TXs (`TX:FGTV:INC_FLARE`, `TX:FGTV:DEC_LEAKS`) now produce non-NaN cost rows on the new SISEPUEDE schema.
- IPPU florinated-gas TX no longer crashes.

## Testing

- `bench_optimization.py` was used as a determinism harness throughout. Hashes captured before and after each change confirm that:
  - The FGTV fix alone preserves the legacy hashes (the legacy test_data does not exercise the new code path).
  - The `output_vars` fix alone preserves the legacy hashes (the test_data does not include the TX that triggers the function).
  - The detail activation correctly changes only `system` and `interactions` hashes; `technical` is bit-identical, confirming no side effects on transformation costs.
- Verified end-to-end against a Libya run by the user; the FGTV cost rows and the new `cb:enfu:fuel_cost:*:*` rows appear with realistic magnitudes.

## Test plan

- [x] Run `python bench_optimization.py` → confirm the hashes match those in the table above.
- [x] Run a real Libya pipeline → confirm `cb:fgtv:technical_cost:flaring:X` and `cb:fgtv:technical_cost:leaks:X` rows are non-empty and non-NaN.
- [x] Run a real Libya pipeline → confirm 47 new `cb:enfu:fuel_cost:<sector>:<fuel>` rows appear.
- [x] Confirm no `NameError` or other runtime exception when iterating over all configured TXs.

https://claude.ai/code/session_01KuZefVrh5WKayFcHagD1Gp